### PR TITLE
Fix setting volume sizes

### DIFF
--- a/operators/dta-platform.yml
+++ b/operators/dta-platform.yml
@@ -23,6 +23,22 @@
   value: Support
 
 # Update storage volume sizes for persistent services
+
+# prometheus-boshrelease sets volume size using persistent_disk, so we remove
+# these defaults and then set using persistent_disk_type to match our cloud-config.
+
+- type: remove
+  path: /instance_groups/name=alertmanager/persistent_disk
+
+- type: remove
+  path: /instance_groups/name=prometheus/persistent_disk
+
+- type: remove
+  path: /instance_groups/name=database/persistent_disk
+
+- type: remove
+  path: /instance_groups/name=grafana/persistent_disk
+
 - type: replace
   path: /instance_groups/name=alertmanager/persistent_disk_type?
   value: 10GB


### PR DESCRIPTION
prometheus-boshrelease recently changed from using persistent_disk_type to
persistent_disk, and BOSH gives an error if you use both persistent_disk_type and persistent_disk. So I have removed the prometheus-boshrelease defaults so we can keep using our cloud-config persistent_disk_type values.