### PR TITLE
prometheus-boshrelease updated basic auth to support a list of users

### DIFF
--- a/operators/dta-platform-nginx-hosts.yml
+++ b/operators/dta-platform-nginx-hosts.yml
@@ -83,11 +83,13 @@
         properties:
           nginx:
             alertmanager:
-              auth_username: admin
-              auth_password: ((alertmanager_password))
+              auth_users:
+                - name: admin
+                  password: ((alertmanager_password))
             prometheus:
-              auth_username: admin
-              auth_password: ((prometheus_password))
+              auth_users:
+                - name: admin
+                  password: ((prometheus_password))
       - name: proxy
         release: instant-https
         properties:
@@ -119,11 +121,13 @@
         properties:
           nginx:
             alertmanager:
-              auth_username: admin
-              auth_password: ((alertmanager_password))
+              auth_users:
+                - name: admin
+                  password: ((alertmanager_password))
             prometheus:
-              auth_username: admin
-              auth_password: ((prometheus_password))
+              auth_users:
+                - name: admin
+                  password: ((prometheus_password))
       - name: proxy
         release: instant-https
         properties:


### PR DESCRIPTION
nginx-prometheus instance-group had been updated, but alertmanager was not.  
this commit fixes alert manager too