### PR TITLE
Fix cron job so it runs daily

### DIFF
--- a/operators/bosh-exporter-fix.yml
+++ b/operators/bosh-exporter-fix.yml
@@ -15,9 +15,9 @@
         - command: /var/vcap/bosh/bin/monit restart bosh_exporter
           minute: '59'
           hour: '15'
-          day: ''
-          month: ''
-          wday: ''
+          day: '*'
+          month: '*'
+          wday: '*'
           user: root
 
 - type: replace


### PR DESCRIPTION
The  [cron-boshrelease has default values for these fields](https://github.com/cloudfoundry-community/cron-boshrelease/blob/master/jobs/cron/spec#L51)  of `*`, but by setting them to empty string the resulting crontab wasnt valid:

```
prometheus/b3ffd5b6-3c5b-4947-bbaa-9c71ea564229:/var/vcap/sys/log# cat /etc/cron.d/cron-boshrelease-crontab
PATH=/var/vcap/packages/bosh_exporter/bin:/bin:/sbin:/usr/sbin:/usr/bin:/usr/local/bin
59 15    root  /var/vcap/bosh/bin/monit restart bosh_exporter
```

I've kept them explicitly set to `*` so it's clearer when reading the ops file how often the command runs.
