### PR TITLE
Remove properties which must be explicitly provided

### DIFF
--- a/operators/dta-platform-monitor-cf-environments.yml
+++ b/operators/dta-platform-monitor-cf-environments.yml
@@ -130,34 +130,3 @@
               client_secret: "((uaa_clients_firehose_exporter_secret_y_cld))"
             metrics:
               environment: ((y_cld_metrics_environment))
-
-- type: replace
-  path: /variables/-
-  value:
-    name: uaa_clients_cf_exporter_secret_b_cld
-    type: password
-- type: replace
-  path: /variables/-
-  value:
-    name: uaa_clients_cf_exporter_secret_d_cld
-    type: password
-- type: replace
-  path: /variables/-
-  value:
-    name: uaa_clients_cf_exporter_secret_y_cld
-    type: password
-- type: replace
-  path: /variables/-
-  value:
-    name: uaa_clients_firehose_exporter_secret_b_cld
-    type: password
-- type: replace
-  path: /variables/-
-  value:
-    name: uaa_clients_firehose_exporter_secret_d_cld
-    type: password
-- type: replace
-  path: /variables/-
-  value:
-    name: uaa_clients_firehose_exporter_secret_y_cld
-    type: password


### PR DESCRIPTION
Having these variables defined means that credhub will silently automatically create them if not provided, but it is better that the operator is notified with an error that they need to provide these vars.