### PR TITLE
Switch to using HAProxy and certs generated by Concourse pipeline

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -43,6 +43,33 @@ resources:
     client_secret: ((bosh_client_secret))
     deployment: prometheus
     target: ((bosh_target))
+- name: cert-alertmanager.s3
+  type: s3
+  source:
+    access_key_id: ((aws_access_key_id))
+    bucket: ((aws_certs_bucket))
+    region_name: ap-southeast-2
+    secret_access_key: ((aws_secret_access_key))
+    server_side_encryption: AES256
+    versioned_file: ((alertmanager_external_hostname)).crt
+- name: cert-grafana.s3
+  type: s3
+  source:
+    access_key_id: ((aws_access_key_id))
+    bucket: ((aws_certs_bucket))
+    region_name: ap-southeast-2
+    secret_access_key: ((aws_secret_access_key))
+    server_side_encryption: AES256
+    versioned_file: ((grafana_external_hostname)).crt
+- name: cert-prometheus.s3
+  type: s3
+  source:
+    access_key_id: ((aws_access_key_id))
+    bucket: ((aws_certs_bucket))
+    region_name: ap-southeast-2
+    secret_access_key: ((aws_secret_access_key))
+    server_side_encryption: AES256
+    versioned_file: ((prometheus_external_hostname)).crt
 resource_types:
 - name: slack-notification
   type: docker-image
@@ -181,8 +208,6 @@ jobs:
         :x: $ATC_EXTERNAL_URL - FAILED cleaning up dev BOSH director
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 - name: ship-it-prod
-  serial_groups:
-  - prometheus
   plan:
   - aggregate:
     - get: stemcell
@@ -199,6 +224,35 @@ jobs:
     - get: deploy-prometheus.git
       passed:
       - test-it
+- name: deploy-to-prod
+  serial_groups:
+  - prometheus
+  plan:
+  - aggregate:
+    - get: stemcell
+      passed:
+      - ship-it-prod
+      trigger: true
+    - get: prometheus-boshrelease.github-release
+      passed:
+      - ship-it-prod
+      params:
+        include_source_tarball: true
+      trigger: true
+    - get: ops.git
+      passed:
+      - ship-it-prod
+      trigger: true
+    - get: deploy-prometheus.git
+      passed:
+      - ship-it-prod
+      trigger: true
+    - get: cert-alertmanager.s3
+      trigger: true
+    - get: cert-grafana.s3
+      trigger: true
+    - get: cert-prometheus.s3
+      trigger: true
   - task: get-dns-values
     config:
       platform: linux
@@ -216,6 +270,24 @@ jobs:
         path: ""
     params:
       DNS_VAR_FILE: ./dns-details/dns-vars.yml
+  - task: fetch-tls-certificates
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: govau/cga-cf-bosh-cli
+      run:
+        path: ./deploy-prometheus.git/ci/scripts/generate-tls-certs.sh
+      inputs:
+      - name: deploy-prometheus.git
+      - name: cert-alertmanager.s3
+      - name: cert-grafana.s3
+      - name: cert-prometheus.s3
+      outputs:
+      - name: tls-details
+    params:
+      TLS_CERTS_VAR_FILE: ./tls-details/tls-certs.yml
   - task: extract-release-src
     file: deploy-prometheus.git/ci/tasks/extract-release-src.yml
   - put: deployment
@@ -276,6 +348,7 @@ jobs:
         y_cld_uaa_url: ((y_cld_uaa_url))
       vars_files:
       - dns-details/dns-vars.yml
+      - tls-details/tls-certs.yml
       - ops.git/monitoring/probe_endpoints.yml
   on_failure:
     put: slack

--- a/ci/scripts/generate-tls-certs.sh
+++ b/ci/scripts/generate-tls-certs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+test $TLS_CERTS_VAR_FILE
+
+PROMETHEUS_EXTERNAL_HOSTNAME=$(dig +short public.prometheus.monitoring.cld.internal ptr)
+PROMETHEUS_EXTERNAL_HOSTNAME=${PROMETHEUS_EXTERNAL_HOSTNAME:0:-1} # Drop trailing period
+PROMETHEUS_CERT="$(cat ./cert-prometheus.s3/${PROMETHEUS_EXTERNAL_HOSTNAME}.crt)"
+
+ALERTMANAGER_EXTERNAL_HOSTNAME=$(dig +short public.alertmanager.monitoring.cld.internal ptr)
+ALERTMANAGER_EXTERNAL_HOSTNAME=${ALERTMANAGER_EXTERNAL_HOSTNAME:0:-1} # Drop trailing period
+ALERTMANAGER_CERT="$(cat ./cert-alertmanager.s3/${ALERTMANAGER_EXTERNAL_HOSTNAME}.crt)"
+
+GRAFANA_EXTERNAL_HOSTNAME=$(dig +short public.grafana.monitoring.cld.internal ptr)
+GRAFANA_EXTERNAL_HOSTNAME=${GRAFANA_EXTERNAL_HOSTNAME:0:-1} # Drop trailing period
+GRAFANA_CERT="$(cat ./cert-grafana.s3/${GRAFANA_EXTERNAL_HOSTNAME}.crt)"
+
+prometheus_tls_cert
+cat > $TLS_CERTS_VAR_FILE <<END_OF_OPS
+---
+alertmanager_tls_cert: '${ALERTMANAGER_CERT}'
+grafana_tls_cert: '${GRAFANA_CERT}'
+prometheus_tls_cert: '${PROMETHEUS_CERT}'
+END_OF_OPS

--- a/operators/dta-platform-nginx-hosts.yml
+++ b/operators/dta-platform-nginx-hosts.yml
@@ -3,14 +3,14 @@
 # - prometheus
 # - alertmanager
 # - grafana
-# nginx instances have HTTPS termination support thanks to https://github.com/govau/instant-https-boshrelease
+# nginx instances have HTTPS termination support thanks to HAProxy in front
 - type: replace
   path: /releases/-
   value:
-    name: instant-https
-    url: https://github.com/govau/instant-https-boshrelease/releases/download/v0.4.0/instant-https-0.4.0.tgz
-    sha1: f603d51ce64efb0145a2842245404946782b1827
-    version: latest
+    name: haproxy
+    version: 8.7.0
+    url: https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/download/v8.7.0/haproxy-8.7.0.tgz
+    sha1: 7898c1894c4b3254aa4a0ade0a02d33cf6c5c59a
 
 - type: replace
   path: /instance_groups/name=grafana/jobs/name=grafana/consumes?
@@ -52,14 +52,15 @@
               auth_users:
                 - name: admin
                   password: ((prometheus_password))
-      - name: proxy
-        release: instant-https
+      - name: haproxy
+        release: haproxy
         properties:
-          hostname: ((prometheus_external_hostname))
-          contact_email: weboperations@digital.gov.au
-          acme_url: https://acme-v01.api.letsencrypt.org/directory
-          backends:
-            - localhost:9090
+          ha_proxy:
+            backend_port: 9090
+            backend_servers: ["127.0.0.1"]
+            disable_http: true
+            ssl_pem:
+            - ((prometheus_tls_cert))
 
 - type: replace
   path: /instance_groups/-
@@ -90,14 +91,15 @@
               auth_users:
                 - name: admin
                   password: ((prometheus_password))
-      - name: proxy
-        release: instant-https
+      - name: haproxy
+        release: haproxy
         properties:
-          hostname: ((alertmanager_external_hostname))
-          contact_email: weboperations@digital.gov.au
-          acme_url: https://acme-v01.api.letsencrypt.org/directory
-          backends:
-            - localhost:9093
+          ha_proxy:
+            backend_port: 9093
+            backend_servers: ["127.0.0.1"]
+            disable_http: true
+            ssl_pem:
+            - ((alertmanager_tls_cert))
 
 - type: replace
   path: /instance_groups/-
@@ -128,11 +130,12 @@
               auth_users:
                 - name: admin
                   password: ((prometheus_password))
-      - name: proxy
-        release: instant-https
+      - name: haproxy
+        release: haproxy
         properties:
-          hostname: ((grafana_external_hostname))
-          contact_email: weboperations@digital.gov.au
-          acme_url: https://acme-v01.api.letsencrypt.org/directory
-          backends:
-            - localhost:3000
+          ha_proxy:
+            backend_port: 3000
+            backend_servers: ["127.0.0.1"]
+            disable_http: true
+            ssl_pem:
+            - ((grafana_tls_cert))


### PR DESCRIPTION
This PR does not take anything off the public internet (yet) - but it does remove the use of Caddy / instant-https-release for this deployment.

It also adds a separate `deploy-to-prod` job, so that a new cert will trigger a deployment, with a previously deliberately "shipped" release.

Not sure if this will work first go, may require a few attempts, but submitting for review of approach.