### PR TITLE
Dont upload the release

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -146,8 +146,6 @@ jobs:
       - deploy-prometheus.git/operators/prometheus-b-cld.yml
       - deploy-prometheus.git/operators/dta-aws-cloud-config.yml
       - deploy-prometheus.git/operators/increase-prometheus-global-scrape-timeout.yml
-      releases:
-      - prometheus-boshrelease.github-release/*.tgz
       stemcells:
       - stemcell/*.tgz
       vars:
@@ -353,8 +351,6 @@ jobs:
       - ops.git/monitoring/alerts-marketplace.yml
       - ops.git/monitoring/alerts-dashboard.yml
       - ops.git/monitoring/alerts-guides.yml
-      releases:
-      - prometheus-boshrelease.github-release/*.tgz
       stemcells:
       - stemcell/*.tgz
       vars:


### PR DESCRIPTION
Have got this running in concourse at the moment... It's bit of a shortcut to fixing `Could not read release: /tmp/build/put/prometheus-boshrelease.github-release/prometheus-23.0.0.tgz is not a valid gzip archive
`

Any objections if we just do this? Or do peops want to properly debug?